### PR TITLE
Deselect event on collection reset (when event no longer exists)

### DIFF
--- a/src/htdocs/js/latesteqs/Catalog.js
+++ b/src/htdocs/js/latesteqs/Catalog.js
@@ -39,6 +39,7 @@ var Catalog = function (options) {
     _this.model.on('change:sort', 'onSort', _this);
     _this.model.on('change:autoUpdate', 'setAutoUpdateInterval', _this);
     _this.model.on('change:feed', 'setAutoUpdateInterval', _this);
+    _this.on('reset', 'checkForEventInCollection', _this);
 
     // keep track of whether there was a load error
     _this.error = false;
@@ -56,6 +57,7 @@ var Catalog = function (options) {
     _this.model.off('change:sort', 'sort', _this);
     _this.model.off('change:autoUpdate', 'setAutoUpdateInterval', _this);
     _this.model.off('change:feed', 'setAutoUpdateInterval', _this);
+    _this.off('reset', 'checkForEventInCollection', _this);
 
     _initialize = null;
     _this = null;
@@ -125,13 +127,34 @@ var Catalog = function (options) {
     _this.error = false;
     _this.metadata = data.metadata;
     _this.reset(data.features, {'silent': true});
-    _this.onSort(); // sort will trigger a reset on the collection
+    // sort will trigger a reset on the collection
+    _this.onSort();
     Message({
         autoclose: 3000,
         container: document.querySelector('.latest-earthquakes-footer'),
         content:'Earthquakes updated',
         classes: 'map-message'
       });
+  };
+
+  /**
+   * Checks the colleciton to see if the selected event exists in the
+   * collection. When the event no longer exists, the model is updated.
+   */
+  _this.checkForEventInCollection = function () {
+    var eq;
+
+    eq = _this.model.get('event');
+    if (!eq) {
+      return;
+    }
+
+    // if event does not exist in the new collection, update model
+    if (!_this.get(eq.id)) {
+      _this.model.set({
+        'event': null
+      });
+    }
   };
 
   /**

--- a/test/spec/latesteqs/CatalogTest.js
+++ b/test/spec/latesteqs/CatalogTest.js
@@ -163,5 +163,38 @@ describe('latesteqs/Catalog', function () {
     });
   });
 
+  describe('checkForEventInCollection', function () {
+    it('clears the selected event when it no longer exists in the collection',
+        function () {
+      var catalog,
+          data,
+          eq;
+
+      data = [
+        {
+          'id': 'us1234'
+        },
+        {
+          'id': 'nc5678'
+        }
+      ];
+
+      eq = {
+        'id': 'us1234'
+      }
+
+      catalog = Catalog({
+        model: Model({
+          'event': eq
+        })
+      });
+
+      catalog.reset(data);
+      expect(catalog.model.get('event').id).to.equal(eq.id);
+
+      catalog.reset([]);
+      expect(catalog.model.get('event')).to.equal(null);
+    });
+  });
 
 });


### PR DESCRIPTION
Update Catalog to listen to a collection reset, and deselect the selected event if it does not exist.

fixes #163 