### PR TITLE
Update MapView to use the leaflet map click event  

### DIFF
--- a/src/htdocs/js/map/MapView.js
+++ b/src/htdocs/js/map/MapView.js
@@ -107,7 +107,7 @@ var MapView = function (options) {
       L.control.mousePosition().addTo(_this.map);
     }
 
-    _this.el.addEventListener('click', _onClick);
+    _this.map.on('click', _onClick);
     _this.map.on('moveend', _onMoveEnd, _this);
     _this.model.on('change:basemap', _onBasemapChange, _this);
     _this.model.on('change:mapposition', _onMapPositionChange, _this);


### PR DESCRIPTION
this will keep events from being deselected on a map drag, but will still allow the event to be deselected on a map click that does not target an event.

fixes #150 