### PR TITLE
Deselect event when no longer in map bounds

### DIFF
--- a/gruntconfig/browserify.js
+++ b/gruntconfig/browserify.js
@@ -34,6 +34,7 @@ ALL_CLASSES = getAliases(JS, [
   'about/AboutView',
 
   'core/Config',
+  'core/MapUtil',
   'core/Formatter',
   'core/GenericCollectionView',
   'core/UrlManager',

--- a/src/htdocs/js/core/MapUtil.js
+++ b/src/htdocs/js/core/MapUtil.js
@@ -1,0 +1,59 @@
+'use strict';
+
+
+// static object with utility methods
+var MapUtil = function () {};
+
+/**
+ * Normalize bounds by shifting the point(latlng) left or right,
+ * until the point is within the offset bounds
+ *
+ * @param bounds {2x2 Array [southWest, northEast] or LatLngBounds object}
+ * @param latlng {Array [lat,lng]}
+ *
+ * @return true if bounds contain [lat,lng], false otherwise.
+ */
+MapUtil.boundsContain = function(bounds, latlng) {
+  var difference,
+      latitude,
+      longitude,
+      maxLatitude,
+      maxLongitude,
+      minLatitude,
+      minLongitude;
+
+  latitude = latlng[0];
+  longitude = latlng[1];
+
+  maxLatitude = bounds[1][0];
+  minLatitude = bounds[0][0];
+
+  maxLongitude = bounds[1][1];
+  minLongitude = bounds[0][1];
+
+  difference = maxLongitude - minLongitude;
+
+  // check latitude values
+  if (latitude > maxLatitude || latitude < minLatitude) {
+    return false;
+  }
+
+  // longitude spans more than 360 degrees (latitude bounds were checked)
+  if (difference >= 360) {
+    return true;
+  }
+
+  // normalize point to be between longitude bounds
+  while (longitude > maxLongitude) {
+    longitude -= 360;
+  }
+  while (longitude < minLongitude) {
+    longitude += 360;
+  }
+
+  // test with adjusted bounds
+  return (longitude <= maxLongitude && longitude >= minLongitude);
+};
+
+
+module.exports = MapUtil;

--- a/src/htdocs/js/list/ListView.js
+++ b/src/htdocs/js/list/ListView.js
@@ -5,6 +5,7 @@ var Accordion = require('accordion/Accordion'),
     DownloadView = require('list/DownloadView'),
     Formatter = require('core/Formatter'),
     GenericCollectionView = require('core/GenericCollectionView'),
+    MapUtil = require('core/MapUtil'),
     ModalView = require('mvc/ModalView'),
     Util = require('util/Util');
 
@@ -126,56 +127,6 @@ var ListView = function (options) {
   };
 
   /**
-   * Normalize bounds by shifting the point(latlng) left or right,
-   * until the point is within the offset bounds
-   *
-   * @param bounds {4x4 Array [southWest, northEast] or LatLngBounds object}
-   * @param latlng {Array [lat,lng]}
-   * @return true if bounds contain [lat,lng], false otherwise.
-   */
-  _this.boundsContain = function(bounds, latlng) {
-    var difference,
-        latitude,
-        longitude,
-        maxLatitude,
-        maxLongitude,
-        minLatitude,
-        minLongitude;
-
-    latitude = latlng[0];
-    longitude = latlng[1];
-
-    maxLatitude = bounds[1][0];
-    minLatitude = bounds[0][0];
-
-    maxLongitude = bounds[1][1];
-    minLongitude = bounds[0][1];
-
-    difference = maxLongitude - minLongitude;
-
-    // check latitude values
-    if (latitude > maxLatitude || latitude < minLatitude) {
-      return false;
-    }
-
-    // longitude spans more than 360 degrees (latitude bounds were checked)
-    if (difference >= 360) {
-      return true;
-    }
-
-    // normalize point to be between longitude bounds
-    while (longitude > maxLongitude) {
-      longitude -= 360;
-    }
-    while (longitude < minLongitude) {
-      longitude += 360;
-    }
-
-    // test with adjusted bounds
-    return (longitude <= maxLongitude && longitude >= minLongitude);
-  };
-
-  /**
    * APIMethod
    *
    * Delegates to the listFormat indicated by the model to generate the
@@ -265,7 +216,7 @@ var ListView = function (options) {
     events = items.filter(function (item) {
       var coordinates;
       coordinates = item.geometry.coordinates;
-      return _this.boundsContain(_bounds, [coordinates[1], coordinates[0]]);
+      return MapUtil.boundsContain(_bounds, [coordinates[1], coordinates[0]]);
     });
 
     return events;

--- a/src/htdocs/js/map/MapView.js
+++ b/src/htdocs/js/map/MapView.js
@@ -6,6 +6,7 @@ require('leaflet/control/ZoomToControl');
 require('map/LegendControl');
 
 var EarthquakeLayer = require('map/EarthquakeLayer'),
+    MapUtil = require('core/MapUtil'),
     Util = require('util/Util'),
     View = require('mvc/View');
 
@@ -173,6 +174,7 @@ var MapView = function (options) {
     _basemap = null;
     _earthquakes = null;
     _onBasemapChange = null;
+    _onClick = null;
     _onMapPositionChange = null;
     _onMoveEnd = null;
     _onOverlayChange = null;
@@ -181,11 +183,6 @@ var MapView = function (options) {
 
     _this.map.removeLayer(_earthquakes);
     _earthquakes.destroy();
-
-    _basemap = null;
-    _earthquakes = null;
-    _onMoveEnd = null;
-    _onClick = null;
 
     _initialize = null;
     _this = null;
@@ -213,7 +210,9 @@ var MapView = function (options) {
   };
 
   _this.onMoveEnd = function () {
-    var bounds;
+    var bounds,
+        eq,
+        latlng;
 
     // only set mapposition when the map is enabled
     if (_this.isEnabled()) {
@@ -224,6 +223,20 @@ var MapView = function (options) {
           [bounds._northEast.lat, bounds._northEast.lng]
         ]
       });
+    }
+
+    // Deselect event when it is no longer within the map bounds
+    bounds = _this.model.get('mapposition');
+    eq = _this.model.get('event');
+
+    if (bounds && eq) {
+      latlng = [eq.geometry.coordinates[1], eq.geometry.coordinates[0]];
+
+      if (!MapUtil.boundsContain(bounds, latlng)) {
+        _this.model.set({
+          'event': null
+        });
+      }
     }
   };
 

--- a/test/spec/core/MapUtilTest.js
+++ b/test/spec/core/MapUtilTest.js
@@ -1,0 +1,36 @@
+/* global chai, describe, it */
+'use strict';
+
+var MapUtil = require('core/MapUtil');
+
+var expect = chai.expect;
+
+
+describe('Unit tests for MapUtil', function () {
+
+  describe('boundsContain', function () {
+    var bounds;
+
+    bounds = [
+      [10, -130], // southwest
+      [30, -110] // northeast
+    ];
+
+    it('contains the point', function () {
+      /* jshint -W030 */
+      expect(MapUtil.boundsContain(bounds, [20, -120])).to.be.true;
+      expect(MapUtil.boundsContain(bounds, [10, -120])).to.be.true;
+      expect(MapUtil.boundsContain(bounds, [20, -130])).to.be.true;
+      /* jshint +W030 */
+    });
+
+    it('does NOT contain the point', function () {
+      /* jshint -W030 */
+      expect(MapUtil.boundsContain(bounds, [40, -140])).to.be.false;
+      expect(MapUtil.boundsContain(bounds, [40, -120])).to.be.false;
+      expect(MapUtil.boundsContain(bounds, [20, -140])).to.be.false;
+      /* jshint +W030 */
+    });
+  });
+
+});

--- a/test/spec/list/ListViewTest.js
+++ b/test/spec/list/ListViewTest.js
@@ -147,35 +147,6 @@ describe('list/ListView', function () {
     view.destroy();
   });
 
-  describe('boundsContain', function () {
-    var bounds,
-        view;
-
-    view = ListView();
-    bounds = [
-      [10, -130], // southwest
-      [30, -110] // northeast
-    ];
-
-    it('contains the point', function () {
-      /* jshint -W030 */
-      expect(view.boundsContain(bounds, [20, -120])).to.be.true;
-      expect(view.boundsContain(bounds, [10, -120])).to.be.true;
-      expect(view.boundsContain(bounds, [20, -130])).to.be.true;
-      /* jshint +W030 */
-    });
-
-    it('does NOT contain the point', function () {
-      /* jshint -W030 */
-      expect(view.boundsContain(bounds, [40, -140])).to.be.false;
-      expect(view.boundsContain(bounds, [40, -120])).to.be.false;
-      expect(view.boundsContain(bounds, [20, -140])).to.be.false;
-      /* jshint +W030 */
-    });
-
-    view.destroy();
-  });
-
   describe('filterEvents', function () {
     var data,
         model,

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ require('./spec/about/AboutViewTest');
 require('./spec/core/ConfigTest');
 require('./spec/core/FormatterTest');
 require('./spec/core/GenericCollectionViewTest');
+require('./spec/core/MapUtilTest');
 require('./spec/core/UrlManagerTest');
 
 require('./spec/latesteqs/CatalogTest');


### PR DESCRIPTION
Deselect event when it is no longer in the map bounds. Move boundsContain into a utility class, for reusability.

fixes #189 