### PR TITLE
Animate EventSummaryView, add ability to swipe the summary closed, Update Message styles

### DIFF
--- a/src/htdocs/css/index.scss
+++ b/src/htdocs/css/index.scss
@@ -19,6 +19,8 @@
 
 @import 'about/_AboutView.scss';
 
+@import 'latesteqs/_Catalog.scss';
+
 @import 'list/_DefaultListFormat.scss';
 @import 'list/_DownloadView.scss';
 @import 'list/_DyfiListFormat.scss';

--- a/src/htdocs/css/latesteqs/_Catalog.scss
+++ b/src/htdocs/css/latesteqs/_Catalog.scss
@@ -1,0 +1,24 @@
+
+.map-message {
+  border-radius: 2px;
+  bottom: 0;
+  box-shadow: 0 1px 8px rgba(0,0,0,0.5);
+  font-size: 0.88em;
+  left: 0;
+  padding: 1em 2em;
+  position: absolute;
+  margin: 0.5em;
+  right: 0;
+}
+
+.webutils-message.webutils-message-closeable > .webutils-message-close {
+  padding: 0 1em;
+  top: auto;
+}
+
+@media screen and (min-width: 640px) {
+  .map-message {
+    max-width: 50%;
+    margin: 0.5em auto;
+  }
+}

--- a/src/htdocs/css/map/_MapView.scss
+++ b/src/htdocs/css/map/_MapView.scss
@@ -12,21 +12,6 @@
   font-size: 16px;
 }
 
-.map-message {
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  text-align: center;
-  margin-bottom: 10px;
-  margin-left: auto;
-  margin-right: auto;
-  background-color: #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 8px rgba(0,0,0,0.5);
-  padding: 7px;
-}
-
 .map-view {
   height: 100%;
 }
@@ -43,12 +28,6 @@
     position: absolute;
     width: 144px;
     top: -29px;
-  }
-}
-
-@media screen and (min-width: 640px) {
-  .map-message {
-    max-width: 50%;
   }
 }
 

--- a/src/htdocs/css/summary/_EventSummaryView.scss
+++ b/src/htdocs/css/summary/_EventSummaryView.scss
@@ -1,14 +1,18 @@
 
 .event-summary-view {
-  bottom: 0;
-  display: none;
+  bottom: -100%;
   font-size: 0.88em;
   padding: 0.5em;
   position: absolute;
   width: 100%;
+  transition: bottom 1s ease;
+
+  &.smoothing {
+    transition: transform 0.3s ease, bottom 0.3s ease;
+  }
 
   &.show {
-    display: block;
+    bottom: 0;
   }
 
   > .event-summary {

--- a/src/htdocs/js/latesteqs/Catalog.js
+++ b/src/htdocs/js/latesteqs/Catalog.js
@@ -148,7 +148,7 @@ var Catalog = function (options) {
         autoclose: 3000,
         container: document.querySelector('.latest-earthquakes-footer'),
         content:'Earthquakes updated',
-        classes: 'map-message'
+        classes: ['map-message', 'info']
       });
   };
 

--- a/test/spec/summary/EventSummaryViewTest.js
+++ b/test/spec/summary/EventSummaryViewTest.js
@@ -65,10 +65,10 @@ describe('summary/EventSummaryView', function () {
   describe('showEventSummary', function () {
     it('shows EventSummaryView.el', function () {
 
-      expect(view.el.className).to.equal('');
+      expect(view.el.classList.contains('show')).to.equal(false);
 
       view.showEventSummary();
-      expect(view.el.className).to.equal('show');
+      expect(view.el.classList.contains('show')).to.equal(true);
     });
   });
 


### PR DESCRIPTION
- Slide EventSummaryView into place from bottom of the screen, slide out on hide
- Use touch to close the EventSummaryView by swiping it towards the bottom of the screen
- Update the Message styles to include the "alert info" styles as well as additional padding