### PR TITLE
Swipe summary closed

### DIFF
--- a/src/htdocs/css/index.scss
+++ b/src/htdocs/css/index.scss
@@ -21,6 +21,8 @@
 
 @import 'about/_AboutView.scss';
 
+@import 'latesteqs/_Catalog.scss';
+
 @import 'list/_DefaultListFormat.scss';
 @import 'list/_DownloadView.scss';
 @import 'list/_DyfiListFormat.scss';

--- a/src/htdocs/css/latesteqs/_Catalog.scss
+++ b/src/htdocs/css/latesteqs/_Catalog.scss
@@ -1,0 +1,24 @@
+
+.map-message {
+  border-radius: 2px;
+  bottom: 0;
+  box-shadow: 0 1px 8px rgba(0,0,0,0.5);
+  font-size: 0.88em;
+  left: 0;
+  padding: 1em 2em;
+  position: absolute;
+  margin: 0.5em;
+  right: 0;
+}
+
+.webutils-message.webutils-message-closeable > .webutils-message-close {
+  padding: 0 1em;
+  top: auto;
+}
+
+@media screen and (min-width: 640px) {
+  .map-message {
+    max-width: 50%;
+    margin: 0.5em auto;
+  }
+}

--- a/src/htdocs/css/map/_MapView.scss
+++ b/src/htdocs/css/map/_MapView.scss
@@ -12,21 +12,6 @@
   font-size: 16px;
 }
 
-.map-message {
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  text-align: center;
-  margin-bottom: 10px;
-  margin-left: auto;
-  margin-right: auto;
-  background-color: #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 8px rgba(0,0,0,0.5);
-  padding: 7px;
-}
-
 .map-view {
   height: 100%;
 }
@@ -43,12 +28,6 @@
     position: absolute;
     width: 144px;
     top: -29px;
-  }
-}
-
-@media screen and (min-width: 640px) {
-  .map-message {
-    max-width: 50%;
   }
 }
 

--- a/src/htdocs/css/summary/_EventSummaryView.scss
+++ b/src/htdocs/css/summary/_EventSummaryView.scss
@@ -1,14 +1,18 @@
 
 .event-summary-view {
-  bottom: 0;
-  display: none;
+  bottom: -100%;
   font-size: 0.88em;
   padding: 0.5em;
   position: absolute;
   width: 100%;
+  transition: bottom 1s ease;
+
+  &.smoothing {
+    transition: transform 0.3s ease, bottom 0.3s ease;
+  }
 
   &.show {
-    display: block;
+    bottom: 0;
   }
 
   > .event-summary {

--- a/src/htdocs/js/latesteqs/Catalog.js
+++ b/src/htdocs/js/latesteqs/Catalog.js
@@ -148,7 +148,7 @@ var Catalog = function (options) {
         autoclose: 3000,
         container: document.querySelector('.latest-earthquakes-footer'),
         content:'Earthquakes updated',
-        classes: 'map-message'
+        classes: ['map-message', 'info']
       });
   };
 

--- a/src/htdocs/js/summary/EventSummaryView.js
+++ b/src/htdocs/js/summary/EventSummaryView.js
@@ -18,6 +18,7 @@ var EventSummaryView = function (options) {
       _onEventSelect,
       _position,
       _positionChange,
+      _summaryHeight,
       _startPosition;
 
   _this = View(options);
@@ -123,10 +124,12 @@ var EventSummaryView = function (options) {
       _this.hideEventSummary();
     } else {
       _this.setTranslate(0);
+      _this.setOpactity(1);
     }
 
     window.setTimeout(function () {
       _this.setTranslate(0);
+      _this.setOpactity(1);
     }, 500);
 
     _positionChange = 0;
@@ -140,7 +143,8 @@ var EventSummaryView = function (options) {
    *         "mousemove" event
    */
   _this.onDragScroll = function (e) {
-    var position,
+    var opacity,
+        position,
         positionChange,
         type;
 
@@ -154,6 +158,13 @@ var EventSummaryView = function (options) {
     _positionChange = positionChange;
     // update the element's position as the user drags
     _this.setTranslate(positionChange);
+
+    if (_positionChange >= (_this.el.clientHeight * 1/3)) {
+      opacity = ((_summaryHeight - _positionChange) / _summaryHeight) * 3/2;
+      _this.setOpactity(opacity);
+    } else if (_positionChange < (_this.el.clientHeight * 1/3)) {
+      _this.setOpactity(1);
+    }
   };
 
   /**
@@ -165,6 +176,7 @@ var EventSummaryView = function (options) {
    *         "mousedown" event OR "touchstart" event
    */
   _this.onDragStart = function (e) {
+    _summaryHeight = _this.el.clientHeight;
 
     if (e.type === 'touchstart') {
       // keeps mouse event from being delivered on touch events
@@ -177,6 +189,10 @@ var EventSummaryView = function (options) {
 
     // ease the close/return to starting position
     _this.el.classList.remove('smoothing');
+  };
+
+  _this.setOpactity = function (opacity) {
+    _this.el.style.opacity = opacity;
   };
 
   /**

--- a/test/spec/summary/EventSummaryViewTest.js
+++ b/test/spec/summary/EventSummaryViewTest.js
@@ -65,10 +65,10 @@ describe('summary/EventSummaryView', function () {
   describe('showEventSummary', function () {
     it('shows EventSummaryView.el', function () {
 
-      expect(view.el.className).to.equal('');
+      expect(view.el.classList.contains('show')).to.equal(false);
 
       view.showEventSummary();
-      expect(view.el.className).to.equal('show');
+      expect(view.el.classList.contains('show')).to.equal(true);
     });
   });
 


### PR DESCRIPTION
- Slide EventSummaryView into place from bottom of the screen, slide out on hide
- Use touch to close the EventSummaryView by swiping it towards the bottom of the screen
- Update the Message styles to include the "alert info" styles as well as additional padding