### PR TITLE
Usgs/earthquake latest earthquakes#202

### DIFF
--- a/src/htdocs/js/map/MapView.js
+++ b/src/htdocs/js/map/MapView.js
@@ -151,6 +151,28 @@ var MapView = function (options) {
     _this.onClick();
   };
 
+  _this.deselectEventonMoveEnd = function () {
+    var bounds,
+       eq,
+       latlng;
+
+    bounds = _this.map.getBounds();
+    eq = _this.model.get('event');
+
+    if (bounds && eq && _this.isFilterEnabled()) {
+     latlng = [eq.geometry.coordinates[1], eq.geometry.coordinates[0]];
+     bounds = [
+         [bounds._southWest.lat, bounds._southWest.lng],
+         [bounds._northEast.lat, bounds._northEast.lng]
+       ];
+
+     if (!MapUtil.boundsContain(bounds, latlng)) {
+       _this.model.set({
+         'event': null
+       });
+     }
+    }
+  };
 
   _this.destroy = Util.compose(function () {
     _this.el.removeEventListener('click', _onClick);
@@ -171,6 +193,7 @@ var MapView = function (options) {
     _onClick = null;
     _onMapPositionChange = null;
     _onMoveEnd = null;
+    _onMoveEndTriggered = null;
     _onOverlayChange = null;
     _onViewModesChange = null;
     _overlays = [];
@@ -236,6 +259,18 @@ var MapView = function (options) {
       }
     }
     return false;
+  };
+
+  _this.isFilterEnabled = function () {
+    var filter;
+
+    filter = _this.model.get('restrictListToMap');
+
+    if (filter.length === 0) {
+      return false;
+    }
+
+    return true;
   };
 
   _this.onBasemapChange = function () {
@@ -313,41 +348,6 @@ var MapView = function (options) {
     }
 
     _ignoreNextMoveEnd = false;
-  };
-
-  _this.deselectEventonMoveEnd = function () {
-    var bounds,
-       eq,
-       latlng;
-
-    bounds = _this.map.getBounds();
-    eq = _this.model.get('event');
-
-    if (bounds && eq && _this.isFilterEnabled()) {
-     latlng = [eq.geometry.coordinates[1], eq.geometry.coordinates[0]];
-     bounds = [
-         [bounds._southWest.lat, bounds._southWest.lng],
-         [bounds._northEast.lat, bounds._northEast.lng]
-       ];
-
-     if (!MapUtil.boundsContain(bounds, latlng)) {
-       _this.model.set({
-         'event': null
-       });
-     }
-    }
-  };
-
-  _this.isFilterEnabled = function () {
-    var filter;
-
-    filter = _this.model.get('restrictListToMap');
-
-    if (filter.length === 0) {
-      return false;
-    }
-
-    return true;
   };
 
   _this.onOverlayChange = function () {

--- a/src/htdocs/js/map/MapView.js
+++ b/src/htdocs/js/map/MapView.js
@@ -312,7 +312,7 @@ var MapView = function (options) {
     bounds = _this.model.get('mapposition');
     eq = _this.model.get('event');
 
-    if (bounds && eq) {
+    if (bounds && eq && _this.isEnabled() && _this.isFilterEnabled()) {
       latlng = [eq.geometry.coordinates[1], eq.geometry.coordinates[0]];
 
       if (!MapUtil.boundsContain(bounds, latlng)) {
@@ -321,6 +321,18 @@ var MapView = function (options) {
         });
       }
     }
+  };
+
+  _this.isFilterEnabled = function () {
+    var filter;
+
+    filter = _this.model.get('restrictListToMap');
+
+    if (filter.length === 0) {
+      return false;
+    }
+
+    return true;
   };
 
   _this.onOverlayChange = function () {


### PR DESCRIPTION
fixes usgs/earthquake-latest-earthquakes#202

- Fixed double tap bug on list.
- Fixed bug that would cause the map to pan back to an event that is selected if the event is dragged outside the map bounds.
- When the filter is selected and an event is dragged outside the map bounds the event is deselected. When the filter is deselected then the event is not deselected.