### PR TITLE
Update EventSummaryView "bottom" attribute to use pixel value instead of percentage based value

### DIFF
--- a/src/htdocs/css/_LatestEarthquakes.scss
+++ b/src/htdocs/css/_LatestEarthquakes.scss
@@ -21,6 +21,7 @@ body {
   box-shadow: 0 1px 8px rgba(0,0,0,0.5);
   display: block;
   height: 50px;
+  position: relative;
   z-index: 4;
 }
 

--- a/src/htdocs/css/summary/_EventSummaryView.scss
+++ b/src/htdocs/css/summary/_EventSummaryView.scss
@@ -1,6 +1,6 @@
 
 .event-summary-view {
-  bottom: -100%;
+  bottom: -500px;
   display: none;
   font-size: 0.88em;
   padding: 0.5em;


### PR DESCRIPTION
fixes #215 

The spec for the bottom CSS property states,
> "A percentage of the containing block's height, used as described in the summary."

Since the footer has a height of zero, the EventSummaryView was never hiding on IE browsers with "bottom:-100%;"
