### PR TITLE
Missing "x" on close button in IE 10

### DIFF
--- a/src/htdocs/css/summary/_EventSummaryView.scss
+++ b/src/htdocs/css/summary/_EventSummaryView.scss
@@ -31,6 +31,10 @@
     font-size: 1em;
     margin: 1em 1em 0;
     padding: 0.5em 1em;
+
+    &:after {
+      content: 'x';
+    }
   }
 }
 

--- a/src/htdocs/js/summary/EventSummaryView.js
+++ b/src/htdocs/js/summary/EventSummaryView.js
@@ -29,7 +29,6 @@ var EventSummaryView = function (options) {
 
     _closeButton = document.createElement('button');
     _closeButton.classList.add('summary-close');
-    _closeButton.innerHTML = 'x';
 
     _formatter = options.formatter || EventSummaryFormat();
     _isVisible = false;


### PR DESCRIPTION
Fixes #217 

Fix issue where close button is missing the "x" on the EventSummaryView. The code `_this.el.innerHTML = "";` was clearing the innerHTML from the close button.