### PR TITLE
Fix IE 10 bug where message is not centered.

### DIFF
--- a/src/htdocs/css/latesteqs/_Catalog.scss
+++ b/src/htdocs/css/latesteqs/_Catalog.scss
@@ -18,7 +18,7 @@
 
 @media screen and (min-width: 640px) {
   .map-message {
-    max-width: 50%;
+    width: 624px;
     margin: 0.5em auto;
   }
 }


### PR DESCRIPTION
For `margin: auto;` to work in IE 10 there must be a defined width. It cannot use "max-width".

fixes #221 

http://stackoverflow.com/questions/16217546/div-does-not-get-centered-using-margin-auto-in-ie9