### PR TITLE
Stop SettingsView from re-rendering each RadioOptionsView and CheckboxOptionsView

### DIFF
--- a/src/htdocs/js/core/GenericCollectionView.js
+++ b/src/htdocs/js/core/GenericCollectionView.js
@@ -121,31 +121,6 @@ var GenericCollectionView = function (options) {
   };
 
   /**
-   * Called during initialization. Creates the base HTML structure into
-   * which all rendering is later performed. Sets up event delegation on
-   * `_this.content` to handle click events.
-   *
-   */
-  _createScaffold = function () {
-    var el;
-
-    el = _this.el;
-
-    el.innerHTML = [
-      '<header class="', _classPrefix, '-header"></header>',
-      '<section class="', _classPrefix, '-content"></section>',
-      '<footer class="', _classPrefix, '-footer"></footer>'
-    ].join('');
-
-    _this.header = el.querySelector('.' + _classPrefix + '-header');
-    _this.content = el.querySelector('.' + _classPrefix + '-content');
-    _this.footer = el.querySelector('.' + _classPrefix + '-footer');
-
-    _this.content.addEventListener('click', _this.onContentClick, _this);
-  };
-
-
-  /**
    * Creates the container element by which all the items in the collection
    * are wraped.
    *

--- a/src/htdocs/js/settings/SettingsView.js
+++ b/src/htdocs/js/settings/SettingsView.js
@@ -33,6 +33,9 @@ var SettingsView = function (options) {
     _config = options.config || Config();
     // initialize the view
     _this.createSkeleton();
+    _this.render();
+
+    _this.model.off('change', 'render', _this);
   };
 
   _this.createSkeleton = function () {


### PR DESCRIPTION
fixes #228 

The render was causing the focus to be removed from the input. 