### PR TITLE
Fix issues with using the browser back button on FeedWarningView 

### DIFF
--- a/src/htdocs/js/latesteqs/Catalog.js
+++ b/src/htdocs/js/latesteqs/Catalog.js
@@ -249,7 +249,6 @@ var Catalog = function (options) {
     max = data.maxAllowed;
 
     if (count > max) {
-
       _feedWarningView.showServerMaxError(data);
       return;
     } else if (count > _maxResults) {
@@ -281,12 +280,20 @@ var Catalog = function (options) {
    * Called when catalog successfully loaded.
    */
   _this.onLoadSuccess = function (data/*, xhr*/) {
+    var activeElement;
+
     if (_loadingMessage !== null) {
       _loadingMessage.hide();
       _loadingMessage = null;
     }
 
     _lastFeedLoaded = _this.model.get('feed');
+
+    if (_feedWarningView.isVisible()) {
+      activeElement = document.activeElement;
+      _feedWarningView.hide();
+      activeElement.focus();
+    }
 
     if (data.metadata.hasOwnProperty('status') &&
         data.metadata.status !== 200) {

--- a/src/htdocs/js/latesteqs/Catalog.js
+++ b/src/htdocs/js/latesteqs/Catalog.js
@@ -289,7 +289,8 @@ var Catalog = function (options) {
 
     _lastFeedLoaded = _this.model.get('feed');
 
-    if (_feedWarningView.isVisible()) {
+    // when the back button is used in the browser
+    if (_feedWarningView.dialog) {
       activeElement = document.activeElement;
       _feedWarningView.hide();
       activeElement.focus();

--- a/src/htdocs/js/latesteqs/FeedWarningView.js
+++ b/src/htdocs/js/latesteqs/FeedWarningView.js
@@ -13,25 +13,30 @@ var FeedWarningView = function (options) {
       _initialize,
 
       _app,
-      _dialog,
-      _maxResults;
+      _maxResults,
+
+      _onDialogHide;
 
   _this = {};
-  _dialog = null;
 
   _initialize = function (options) {
     options = Util.extend({}, _DEFAULTS, options);
     _app = options.app || {};
     _maxResults = options.maxResults || 0;
+
+    _this.callback = null;
+    _this.data = null;
+    _this.dialog = null;
   };
 
-  _this.destroy = function () {
-    _app = null;
-    _maxResults = null;
-    _dialog = null;
-
-    _initialize = null;
-    _this = null;
+  /**
+   * Hides the dialog and executes the callback.
+   *
+   * Triggered by _this.dialog.hide()
+   */
+  _onDialogHide = function () {
+    _this.hide();
+    _this.onDialogContinue();
   };
 
   /**
@@ -43,6 +48,19 @@ var FeedWarningView = function (options) {
     } else if (window.external && window.external.AddFavorite) { // IE
       window.external.AddFavorite(window.location, document.title);
     }
+  };
+
+  /**
+   * Cleans up
+   */
+  _this.destroy = function () {
+    _onDialogHide = null;
+
+    _app = null;
+    _maxResults = null;
+
+    _initialize = null;
+    _this = null;
   };
 
     /**
@@ -94,38 +112,61 @@ var FeedWarningView = function (options) {
     return p;
   };
 
+  /**
+   * Hides dialog and unbinds event
+   */
   _this.hide = function () {
-    _dialog.hide();
-    _dialog = null;
-  };
-
-  _this.isVisible = function () {
-    if (_dialog !== null) {
-      return true;
+    if (_this.dialog) {
+      _this.dialog.off('hide', _onDialogHide);
+      _this.dialog.hide();
+      _this.dialog = null;
     }
-    return false;
   };
 
+  /**
+   * Executes the callback, when a callback exists for the
+   * "Continue anyway" option
+   *
+   * Called when the "continue anyway" button is clicked, or the modal is
+   * closed without selecting any of the available options.
+   */
+  _this.onDialogContinue = function () {
+    if (_this.callback) {
+      _this.callback(_this.data);
+    }
+  };
+
+  /**
+   * Displays a modal dialog to the user indicating that the feed may be too
+   * large to display in the browser.
+   *
+   * @param callback {Function}
+   *      function to execute when "continue anyway" button is clicked
+   *
+   * @param data {Object}
+   *      data to be passed to the callback
+   */
   _this.showClientMaxError = function (callback, data) {
     var message;
 
+    _this.callback = callback;
+    _this.data = data;
+
     message = document.createElement('div');
 
-    _dialog = ModalView(message, {
+    _this.dialog = ModalView(message, {
       title: 'Caution',
       closable: false,
       classes: ['modal-warning', 'catalog'],
       buttons: [
         {
           callback: function () {
-            _dialog.hide();
-            _dialog = null;
-            callback(data);
+            _this.hide();
+            _this.onDialogContinue();
           },
           text: 'Continue anyway',
         }
-      ],
-      destroyOnHide: true
+      ]
     });
 
     message.innerHTML = [
@@ -139,31 +180,43 @@ var FeedWarningView = function (options) {
     message.appendChild(_this.getDialogModifySearchAction(
         'We recommend at most ' + _maxResults + ' earthquakes for your ' +
         'device.'));
-    message.appendChild(_this.getDialogRevertAction(_dialog));
+    message.appendChild(_this.getDialogRevertAction(_this.dialog));
 
-    _dialog.show();
+    _this.dialog.show();
+    _this.dialog.on('hide', _onDialogHide);
   };
 
+  /**
+   * Displays a modal dialog to the user indicating that there is no data in
+   * the currently loaded feed/search.
+   *
+   * @param callback {Function}
+   *      function to execute when "continue anyway" button is clicked
+   *
+   * @param data {Object}
+   *      data to be passed to the callback
+   */
   _this.showNoDataError = function (callback, data) {
     var message;
 
+    _this.callback = callback;
+    _this.data = data;
+
     message = document.createElement('div');
 
-    _dialog = ModalView(message, {
+    _this.dialog = ModalView(message, {
       title: 'Caution',
       closable: true,
       classes: ['modal-warning', 'catalog'],
       buttons: [
         {
           callback: function () {
-            _dialog.hide();
-            _dialog = null;
-            callback(data);
+            _this.hide();
+            _this.onDialogContinue();
           },
           text: 'Continue'
         }
-      ],
-      destroyOnHide: true
+      ]
     });
 
     message.innerHTML = [
@@ -176,7 +229,8 @@ var FeedWarningView = function (options) {
       '</p>'
     ].join('');
 
-    _dialog.show();
+    _this.dialog.show();
+    _this.dialog.on('hide', _onDialogHide);
   };
 
   /**
@@ -201,7 +255,7 @@ var FeedWarningView = function (options) {
 
     message = document.createElement('div');
     supportsBookmark = _this.supportsBookmark();
-    _dialog = ModalView(message, {
+    _this.dialog = ModalView(message, {
       title: 'Error',
       closable: false,
       classes: ['modal-error', 'catalog'],
@@ -227,21 +281,28 @@ var FeedWarningView = function (options) {
     message.appendChild(_this.getDialogModifySearchAction(
         'See the error message above for details about why the current ' +
         'request failed and modify appropriately.'));
-    message.appendChild(_this.getDialogRevertAction(_dialog));
+    message.appendChild(_this.getDialogRevertAction(_this.dialog));
 
     if (supportsBookmark) {
       message.querySelector('.bookmark').addEventListener(
           'click', _this.addBookmark);
     }
 
-    _dialog.show();
+    _this.dialog.show();
   };
 
+
+  /**
+   * Displays a modal dialog to the user if the query was too large to return
+   *
+   * @param data {Object}
+   *      json response with error data
+   */
   _this.showServerMaxError = function (data) {
     var message;
 
     message = document.createElement('div');
-    _dialog = ModalView(message, {
+    _this.dialog = ModalView(message, {
       title: 'Error',
       closable: false,
       classes: ['modal-error', 'catalog'],
@@ -258,9 +319,9 @@ var FeedWarningView = function (options) {
     message.appendChild(_this.getDialogModifySearchAction(
         'We recommend at most ' + _maxResults + ' earthquakes for your ' +
         'device.'));
-    message.appendChild(_this.getDialogRevertAction(_dialog));
+    message.appendChild(_this.getDialogRevertAction(_this.dialog));
 
-    _dialog.show();
+    _this.dialog.show();
   };
 
   /**
@@ -285,7 +346,7 @@ var FeedWarningView = function (options) {
     var message;
 
     message = document.createElement('div');
-    _dialog = ModalView(message, {
+    _this.dialog = ModalView(message, {
       title: 'Error',
       closable: false,
       classes: ['modal-error', 'catalog'],
@@ -300,9 +361,9 @@ var FeedWarningView = function (options) {
     message.appendChild(_this.getDialogModifySearchAction(
         'See the error message above for details about why the current ' +
         'request failed and modify appropriately.'));
-    message.appendChild(_this.getDialogRevertAction(_dialog));
+    message.appendChild(_this.getDialogRevertAction(_this.dialog));
 
-    _dialog.show();
+    _this.dialog.show();
   };
 
   /**

--- a/src/htdocs/js/latesteqs/FeedWarningView.js
+++ b/src/htdocs/js/latesteqs/FeedWarningView.js
@@ -13,9 +13,11 @@ var FeedWarningView = function (options) {
       _initialize,
 
       _app,
+      _dialog,
       _maxResults;
 
   _this = {};
+  _dialog = null;
 
   _initialize = function (options) {
     options = Util.extend({}, _DEFAULTS, options);
@@ -26,6 +28,7 @@ var FeedWarningView = function (options) {
   _this.destroy = function () {
     _app = null;
     _maxResults = null;
+    _dialog = null;
 
     _initialize = null;
     _this = null;
@@ -91,21 +94,32 @@ var FeedWarningView = function (options) {
     return p;
   };
 
+  _this.hide = function () {
+    _dialog.hide();
+    _dialog = null;
+  };
+
+  _this.isVisible = function () {
+    if (_dialog !== null) {
+      return true;
+    }
+    return false;
+  };
 
   _this.showClientMaxError = function (callback, data) {
-    var message,
-        dialog;
+    var message;
 
     message = document.createElement('div');
 
-    dialog = ModalView(message, {
+    _dialog = ModalView(message, {
       title: 'Caution',
       closable: false,
       classes: ['modal-warning', 'catalog'],
       buttons: [
         {
           callback: function () {
-            dialog.hide();
+            _dialog.hide();
+            _dialog = null;
             callback(data);
           },
           text: 'Continue anyway',
@@ -125,25 +139,25 @@ var FeedWarningView = function (options) {
     message.appendChild(_this.getDialogModifySearchAction(
         'We recommend at most ' + _maxResults + ' earthquakes for your ' +
         'device.'));
-    message.appendChild(_this.getDialogRevertAction(dialog));
+    message.appendChild(_this.getDialogRevertAction(_dialog));
 
-    dialog.show();
+    _dialog.show();
   };
 
   _this.showNoDataError = function (callback, data) {
-    var message,
-        dialog;
+    var message;
 
     message = document.createElement('div');
 
-    dialog = ModalView(message, {
+    _dialog = ModalView(message, {
       title: 'Caution',
       closable: true,
       classes: ['modal-warning', 'catalog'],
       buttons: [
         {
           callback: function () {
-            dialog.hide();
+            _dialog.hide();
+            _dialog = null;
             callback(data);
           },
           text: 'Continue'
@@ -162,7 +176,7 @@ var FeedWarningView = function (options) {
       '</p>'
     ].join('');
 
-    dialog.show();
+    _dialog.show();
   };
 
   /**
@@ -182,13 +196,12 @@ var FeedWarningView = function (options) {
      * @see Catalog.js#_showServiceError
      */
   _this.showServerError = function () {
-    var dialog,
-        message,
+    var message,
         supportsBookmark;
 
     message = document.createElement('div');
     supportsBookmark = _this.supportsBookmark();
-    dialog = ModalView(message, {
+    _dialog = ModalView(message, {
       title: 'Error',
       closable: false,
       classes: ['modal-error', 'catalog'],
@@ -214,22 +227,21 @@ var FeedWarningView = function (options) {
     message.appendChild(_this.getDialogModifySearchAction(
         'See the error message above for details about why the current ' +
         'request failed and modify appropriately.'));
-    message.appendChild(_this.getDialogRevertAction(dialog));
+    message.appendChild(_this.getDialogRevertAction(_dialog));
 
     if (supportsBookmark) {
       message.querySelector('.bookmark').addEventListener(
           'click', _this.addBookmark);
     }
 
-    dialog.show();
+    _dialog.show();
   };
 
   _this.showServerMaxError = function (data) {
-    var message,
-        dialog;
+    var message;
 
     message = document.createElement('div');
-    dialog = ModalView(message, {
+    _dialog = ModalView(message, {
       title: 'Error',
       closable: false,
       classes: ['modal-error', 'catalog'],
@@ -246,9 +258,9 @@ var FeedWarningView = function (options) {
     message.appendChild(_this.getDialogModifySearchAction(
         'We recommend at most ' + _maxResults + ' earthquakes for your ' +
         'device.'));
-    message.appendChild(_this.getDialogRevertAction(dialog));
+    message.appendChild(_this.getDialogRevertAction(_dialog));
 
-    dialog.show();
+    _dialog.show();
   };
 
   /**
@@ -270,11 +282,10 @@ var FeedWarningView = function (options) {
    * @see Catalog.js#_showServerError
    */
   _this.showServiceError = function (data) {
-    var message,
-        dialog;
+    var message;
 
     message = document.createElement('div');
-    dialog = ModalView(message, {
+    _dialog = ModalView(message, {
       title: 'Error',
       closable: false,
       classes: ['modal-error', 'catalog'],
@@ -289,9 +300,9 @@ var FeedWarningView = function (options) {
     message.appendChild(_this.getDialogModifySearchAction(
         'See the error message above for details about why the current ' +
         'request failed and modify appropriately.'));
-    message.appendChild(_this.getDialogRevertAction(dialog));
+    message.appendChild(_this.getDialogRevertAction(_dialog));
 
-    dialog.show();
+    _dialog.show();
   };
 
   /**

--- a/src/htdocs/js/latesteqs/LatestEarthquakes.js
+++ b/src/htdocs/js/latesteqs/LatestEarthquakes.js
@@ -159,6 +159,7 @@ var LatestEarthquakes = function (options) {
     _settingsView = SettingsView({
       el: el.querySelector('.settings-view'),
       catalog: _catalog,
+      config: _config,
       model: _this.model
     });
 


### PR DESCRIPTION
When a large feed warning is up, and the user hits the back button, the dialog stays put, even though the feed is refreshed behind the dialog.

fixes #237 