### PR TITLE
Update zoom control styles so that they are always visible.

### DIFF
--- a/src/htdocs/css/map/_MapView.scss
+++ b/src/htdocs/css/map/_MapView.scss
@@ -16,6 +16,12 @@
   height: 100%;
 }
 
+.leaflet-touch .leaflet-top > .leaflet-control-zoom {
+  border-radius: 2px;
+  box-shadow: 0 1px 1px #333;
+  display: block;
+}
+
 @media screen and (min-width: 465px) {
 
   .legend-control {


### PR DESCRIPTION
I couldn't find anything in the leaflet api that would allow the control to always remain visible, so I updated the _MapView.scss

fixes #242 