### PR TITLE
Hide EventSummaryView using dislay: none; so that the users cannot scroll the overflow on the list

### DIFF
--- a/src/htdocs/css/summary/_EventSummaryView.scss
+++ b/src/htdocs/css/summary/_EventSummaryView.scss
@@ -1,7 +1,9 @@
+.event-summary-view-container {
+  display: none;
+}
 
 .event-summary-view {
   bottom: -500px;
-  display: none;
   font-size: 0.88em;
   padding: 0.5em;
   position: absolute;
@@ -14,6 +16,10 @@
 
   &.show {
     bottom: 0;
+  }
+
+  &.hide {
+    display: none;
   }
 
   > .event-summary {
@@ -42,10 +48,11 @@
 .mode-list,
 .mode-map {
 
-  + .latest-earthquakes-footer > .event-summary-view {
+  + .latest-earthquakes-footer > .event-summary-view-container {
     display: block;
   }
 }
+
 
 @media screen and (min-width: 640px) {
   .event-summary-view {

--- a/src/htdocs/js/latesteqs/LatestEarthquakes.js
+++ b/src/htdocs/js/latesteqs/LatestEarthquakes.js
@@ -122,7 +122,9 @@ var LatestEarthquakes = function (options) {
           '</div>' +
         '</div>' +
         '<footer class="latest-earthquakes-footer">' +
-          '<div class="event-summary-view"></div>' +
+          '<div class="event-summary-view-container">' +
+            '<div class="event-summary-view"></div>' +
+          '</div>' +
         '</footer>';
 
     _content = el.querySelector('.latest-earthquakes-content');

--- a/src/htdocs/js/summary/EventSummaryView.js
+++ b/src/htdocs/js/summary/EventSummaryView.js
@@ -92,6 +92,9 @@ var EventSummaryView = function (options) {
     _this.deselectEvent();
     _this.el.classList.remove('smoothing');
     _this.el.classList.remove('show');
+    window.setTimeout(function () {
+      _this.el.classList.add('hide');
+    }, 300);
     _isVisible = false;
   };
 
@@ -242,8 +245,11 @@ var EventSummaryView = function (options) {
    * Toggles the EventSummaryView into view.
    */
   _this.showEventSummary = function () {
+    _this.el.classList.remove('hide');
     _this.el.classList.add('smoothing');
-    _this.el.classList.add('show');
+    window.setTimeout(function () {
+      _this.el.classList.add('show');
+    }, 1);
     _isVisible = true;
   };
 


### PR DESCRIPTION
fixes #261 

This addresses a small bug where user's can continue to scroll the list once they have reached the bottom (on iOS devices). 

To recreate you have to wait for the elastic rebound before you continue scrolling from the bottom. 