### PR TITLE
Use overflow:hidden to keep list from scrolling past end when EventSummaryView is hidden

### DIFF
--- a/src/htdocs/css/_LatestEarthquakes.scss
+++ b/src/htdocs/css/_LatestEarthquakes.scss
@@ -73,8 +73,9 @@ body {
 }
 
 .latest-earthquakes-footer {
-  bottom: 0;
-  height: 0;
+  height: 100%;
+  overflow: hidden;
+  pointer-events: none;
 }
 
 .latest-earthquakes-content {

--- a/src/htdocs/css/_LatestEarthquakes.scss
+++ b/src/htdocs/css/_LatestEarthquakes.scss
@@ -73,9 +73,10 @@ body {
 }
 
 .latest-earthquakes-footer {
-  height: 100%;
+  bottom: 0;
   overflow: hidden;
   pointer-events: none;
+  top: 0;
 }
 
 .latest-earthquakes-content {

--- a/src/htdocs/css/summary/_EventSummaryView.scss
+++ b/src/htdocs/css/summary/_EventSummaryView.scss
@@ -1,10 +1,14 @@
 
+/* Override inherited property, allow pointer events on EventSummaryView */
+.latest-earthquakes-footer > .event-summary-view {
+  pointer-events: auto;
+}
+
 .event-summary-view {
   bottom: -500px;
   display: none;
   font-size: 0.88em;
   padding: 0.5em;
-  pointer-events: auto;
   position: absolute;
   width: 100%;
   transition: bottom 1s ease;

--- a/src/htdocs/css/summary/_EventSummaryView.scss
+++ b/src/htdocs/css/summary/_EventSummaryView.scss
@@ -4,6 +4,7 @@
   display: none;
   font-size: 0.88em;
   padding: 0.5em;
+  pointer-events: auto;
   position: absolute;
   width: 100%;
   transition: bottom 1s ease;


### PR DESCRIPTION
fixes #261 

I didn't think I could use `overflow: hidden;` on `.latest-earthquakes-footer` since it has a `height: 0;` property that would stop the EventSummaryView from ever being visible. Then if you gave the footer a height it would block click events, but this solution seems to work.